### PR TITLE
Improve horse history query

### DIFF
--- a/src/main/java/com/example/demo/service/RaceService.java
+++ b/src/main/java/com/example/demo/service/RaceService.java
@@ -175,6 +175,11 @@ public class RaceService {
                 .beforeRace(true)
                 .build()).get(0);
         
+        // 対象馬のIDリストを取得
+        List<Integer> targetHorseIds = targeRace.getRaceHorses().stream()
+                .map(raceHorse -> raceHorse.getHorse().getId())
+                .collect(Collectors.toList());
+
         // 過去レース取得時は全馬データを取得するため、fetchRaceWithAllHorsesを使用
         List<Race> recentRanRaces = raceRepository.fetchRaceWithAllHorses(
                 RaceQueryParam.builder()
@@ -184,13 +189,9 @@ public class RaceService {
                         .stadiums(query.getStadiums())
                         .minRaceLength(query.getMinRaceLength())
                         .maxRaceLength(query.getMaxRaceLength())
+                        .horseIds(targetHorseIds)
                         .build()
         );
-        
-        // 対象馬のIDリストを取得
-        List<Integer> targetHorseIds = targeRace.getRaceHorses().stream()
-                .map(raceHorse -> raceHorse.getHorse().getId())
-                .collect(Collectors.toList());
         return targeRace.getRaceHorses().stream()
                 .map(
                         raceHorse -> RecentHorseResultDto.builder()

--- a/src/main/resources/com/example/demo/repository/RaceRepository.xml
+++ b/src/main/resources/com/example/demo/repository/RaceRepository.xml
@@ -382,10 +382,27 @@
             <if test="queryParam.raceDate != null">
                 AND raceDate = #{queryParam.raceDate}
             </if>
-            <if test="queryParam.startRaceDate != null">
-                AND raceDate >= #{queryParam.startRaceDate}
+            <if test="queryParam.horseIds != null and queryParam.horseIds.size > 0">
+                AND race.id IN (
+                    SELECT DISTINCT sr.id
+                    FROM race sr
+                    JOIN raceHorse srh ON sr.id = srh.raceId
+                    WHERE srh.horseId IN
+                    <foreach item="horseId" collection="queryParam.horseIds" open="(" separator="," close=")">
+                        #{horseId}
+                    </foreach>
+                    <if test="queryParam.startRaceDate != null">
+                        AND sr.raceDate &gt;= #{queryParam.startRaceDate}
+                    </if>
+                    <if test="queryParam.endRaceDate != null">
+                        AND sr.raceDate &lt; #{queryParam.endRaceDate}
+                    </if>
+                )
             </if>
-            <if test="queryParam.endRaceDate != null">
+            <if test="(queryParam.horseIds == null or queryParam.horseIds.size == 0) and queryParam.startRaceDate != null">
+                AND raceDate &gt;= #{queryParam.startRaceDate}
+            </if>
+            <if test="(queryParam.horseIds == null or queryParam.horseIds.size == 0) and queryParam.endRaceDate != null">
                 AND raceDate &lt; #{queryParam.endRaceDate}
             </if>
             <if test="queryParam.minRaceLength != null">


### PR DESCRIPTION
## Summary
- optimize `fetchRaceWithAllHorses` to filter by horse IDs and period using a subquery
- pass horse ID list in `RaceService.fetchHorseRanRecentRace`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684bdc35d8bc8323869aed757074166a