### PR TITLE
Improve race swagger

### DIFF
--- a/src/main/java/com/example/demo/contoller/RaceController.java
+++ b/src/main/java/com/example/demo/contoller/RaceController.java
@@ -13,6 +13,8 @@ import com.example.demo.service.dto.RecentRaceQuery;
 import com.example.demo.valueobject.RaceCondition;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -68,7 +70,10 @@ public class RaceController {
      */
     @GetMapping
     @Operation(summary = "Get race", description = "Fetch race information")
-    List<GetRaceResponse> getRace(Integer raceId,@RequestParam(required = false,defaultValue = "true") Boolean beforeFlag,@RequestParam(required = false,defaultValue = "false") Boolean payoutFlag) {
+    List<GetRaceResponse> getRace(
+            @Parameter(description = "レースID。YYYYMMDD+開催地+レース番号の組み合わせ", example = "202301010801") Integer raceId,
+            @Parameter(description = "開催前の情報を取得するか", example = "true") @RequestParam(required = false,defaultValue = "true") Boolean beforeFlag,
+            @Parameter(description = "払戻情報を含めるか", example = "false") @RequestParam(required = false,defaultValue = "false") Boolean payoutFlag) {
         return raceService.fetchRace(raceId,beforeFlag,payoutFlag).stream()
                 .map(getRaceResponseConverter::convert)
                 .collect(Collectors.toList());
@@ -84,11 +89,12 @@ public class RaceController {
     @GetMapping("/recent")
     @Operation(summary = "Get recent race result", description = "Fetch recent race results before the target race")
     public List<GetHorseRaceResultResponse> getRecentRaceResult(
-            Integer raceId,
-            String raceCondition,
-            @RequestParam(required = false) List<String> stadiums,
-            @RequestParam(required = false) Integer minRaceLength,
-            @RequestParam(required = false) Integer maxRaceLength
+            @Parameter(description = "対象レースID", example = "202301010801") Integer raceId,
+            @Parameter(description = "馬場状態", example = "良",
+                    schema = @Schema(allowableValues = {"良","稍重","重","不良"})) String raceCondition,
+            @Parameter(description = "対象スタジアム", example = "[\"東京\",\"阪神\"]") @RequestParam(required = false) List<String> stadiums,
+            @Parameter(description = "最低距離", example = "1200", minimum = "1000", maximum = "3600") @RequestParam(required = false) Integer minRaceLength,
+            @Parameter(description = "最大距離", example = "1800", minimum = "1000", maximum = "3600") @RequestParam(required = false) Integer maxRaceLength
     ){
         RecentRaceQuery query = RecentRaceQuery.builder()
                 .raceId(raceId)

--- a/src/main/java/com/example/demo/contoller/response/GetHorseRaceResultResponse.java
+++ b/src/main/java/com/example/demo/contoller/response/GetHorseRaceResultResponse.java
@@ -12,16 +12,16 @@ import java.util.List;
 @Builder
 @Schema(description = "馬のレース結果レスポンス")
 public class GetHorseRaceResultResponse {
-    @Schema(description = "馬ID")
+    @Schema(description = "馬ID", example = "123")
     private int id;
 
-    @Schema(description = "馬名")
+    @Schema(description = "馬名", example = "ディープインパクト")
     private String name;
 
-    @Schema(description = "枠番")
+    @Schema(description = "枠番", example = "5")
     private Integer frameNumber;
 
-    @Schema(description = "ハンデ")
+    @Schema(description = "ハンデ", example = "55")
     private Integer handicap;
 
     @Schema(description = "直近レース結果一覧")

--- a/src/main/java/com/example/demo/contoller/response/GetRaceResponse.java
+++ b/src/main/java/com/example/demo/contoller/response/GetRaceResponse.java
@@ -12,49 +12,56 @@ import java.util.List;
 @Builder
 @Schema(description = "レース情報レスポンス")
 public class GetRaceResponse {
-    @Schema(description = "レース名")
+    @Schema(description = "レース名", example = "日本ダービー")
     String raceName;
 
-    @Schema(description = "レース種別")
+    @Schema(description = "レース種別", example = "芝",
+            allowableValues = {"芝","ダート","障害"})
     String raceType;
 
-    @Schema(description = "距離")
+    @Schema(description = "距離", example = "2400", minimum = "1000", maximum = "3600")
     int raceLength;
 
-    @Schema(description = "回り")
+    @Schema(description = "回り", example = "右",
+            allowableValues = {"左","右"})
     String clockwise;
 
-    @Schema(description = "馬場状態")
+    @Schema(description = "馬場状態", example = "良",
+            allowableValues = {"良","稍重","重","不良"})
     String raceCondition;
 
-    @Schema(description = "天気")
+    @Schema(description = "天気", example = "晴",
+            allowableValues = {"晴","曇","雨","小雨"})
     String raceWeather;
 
-    @Schema(description = "グレード")
+    @Schema(description = "グレード", example = "G1",
+            allowableValues = {"G1","G2","G3","リステッド","オープン","3勝クラス",
+                    "2勝クラス","1勝クラス","新馬","未勝利"})
     String grade;
 
-    @Schema(description = "年齢制限")
+    @Schema(description = "年齢制限", example = "3歳以上",
+            allowableValues = {"2歳","3歳","3歳以上","4歳以上"})
     String oldLimit;
 
-    @Schema(description = "開催日")
+    @Schema(description = "開催日", example = "2023-05-28")
     String raceDate;
 
-    @Schema(description = "レースID")
+    @Schema(description = "レースID", example = "202301010801")
     int id;
 
-    @Schema(description = "回数")
+    @Schema(description = "回数", example = "11")
     int round;
 
-    @Schema(description = "スタジアム")
+    @Schema(description = "スタジアム", example = "東京")
     String stadium;
 
-    @Schema(description = "出走頭数")
+    @Schema(description = "出走頭数", example = "18")
     int horseCount;
 
-    @Schema(description = "開催日番号")
+    @Schema(description = "開催日番号", example = "2")
     Integer stadiumDay;
 
-    @Schema(description = "開催回番号")
+    @Schema(description = "開催回番号", example = "1")
     Integer stadiumRound;
 
     @Schema(description = "レース馬情報")

--- a/src/main/java/com/example/demo/contoller/response/dto/HorseResponse.java
+++ b/src/main/java/com/example/demo/contoller/response/dto/HorseResponse.java
@@ -14,6 +14,7 @@ public class HorseResponse {
     @Schema(description = "馬名")
     String name;
 
-    @Schema(description = "性別")
+    @Schema(description = "性別",
+            allowableValues = {"牝","牡","せん"})
     String gender;
 }

--- a/src/main/java/com/example/demo/contoller/response/dto/RaceResponse.java
+++ b/src/main/java/com/example/demo/contoller/response/dto/RaceResponse.java
@@ -8,48 +8,55 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Builder
 @Schema(description = "レースレスポンス")
 public class RaceResponse {
-    @Schema(description = "レース名")
+    @Schema(description = "レース名", example = "日本ダービー")
     String raceName;
 
-    @Schema(description = "レース種別")
+    @Schema(description = "レース種別", example = "芝",
+            allowableValues = {"芝","ダート","障害"})
     String raceType;
 
-    @Schema(description = "距離")
+    @Schema(description = "距離", example = "2400", minimum = "1000", maximum = "3600")
     int raceLength;
 
-    @Schema(description = "回り")
+    @Schema(description = "回り", example = "右",
+            allowableValues = {"左","右"})
     String clockwise;
 
-    @Schema(description = "馬場状態")
+    @Schema(description = "馬場状態", example = "良",
+            allowableValues = {"良","稍重","重","不良"})
     String raceCondition;
 
-    @Schema(description = "天気")
+    @Schema(description = "天気", example = "晴",
+            allowableValues = {"晴","曇","雨","小雨"})
     String raceWeather;
 
-    @Schema(description = "グレード")
+    @Schema(description = "グレード", example = "G1",
+            allowableValues = {"G1","G2","G3","リステッド","オープン","3勝クラス",
+                    "2勝クラス","1勝クラス","新馬","未勝利"})
     String grade;
 
-    @Schema(description = "年齢制限")
+    @Schema(description = "年齢制限", example = "3歳以上",
+            allowableValues = {"2歳","3歳","3歳以上","4歳以上"})
     String oldLimit;
 
-    @Schema(description = "開催日")
+    @Schema(description = "開催日", example = "2023-05-28")
     String raceDate;
 
-    @Schema(description = "レースID")
+    @Schema(description = "レースID", example = "202301010801")
     int id;
 
-    @Schema(description = "回数")
+    @Schema(description = "回数", example = "11")
     int round;
 
-    @Schema(description = "スタジアム")
+    @Schema(description = "スタジアム", example = "東京")
     String stadium;
 
-    @Schema(description = "出走頭数")
+    @Schema(description = "出走頭数", example = "18")
     int horseCount;
 
-    @Schema(description = "開催日番号")
+    @Schema(description = "開催日番号", example = "2")
     int stadiumDay;
 
-    @Schema(description = "開催回番号")
+    @Schema(description = "開催回番号", example = "1")
     int stadiumRound;
 }

--- a/src/main/java/com/example/demo/contoller/response/dto/ResultResponse.java
+++ b/src/main/java/com/example/demo/contoller/response/dto/ResultResponse.java
@@ -38,15 +38,15 @@ public class ResultResponse {
     @Schema(description = "対象レース上がり差")
     float devTargetRaceLastRapTime;
 
-    @Schema(description = "平均タイム")
+    @Schema(description = "平均タイム", example = "0.5", minimum = "0", maximum = "1")
     float normalFullTime;
 
-    @Schema(description = "平均上がり")
+    @Schema(description = "平均上がり", example = "0.5", minimum = "0", maximum = "1")
     float normalLastRapTime;
 
-    @Schema(description = "対象レース平均タイム")
+    @Schema(description = "対象レース平均タイム", example = "0.5", minimum = "0", maximum = "1")
     float normalTargetRaceFullTime;
 
-    @Schema(description = "対象レース平均上がり")
+    @Schema(description = "対象レース平均上がり", example = "0.5", minimum = "0", maximum = "1")
     float normalTargetRaceLastRapTime;
 }


### PR DESCRIPTION
## Summary
- enrich API docs for `/race` and `/race/recent`
- add enum values for parameters and models
- document normalized fields as 0-1 range in race results

## Testing
- `./mvnw -q -DskipTests package` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684df7fb48e48323a404fd4f1951f4b5